### PR TITLE
メッセージの時間表示の修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
メッセージ投稿時間が日本時間ではなかったため、日本時間になるように修正

# Why
正確な時間が表示されるようにするため